### PR TITLE
クラスbusiness__contentの配置

### DIFF
--- a/style.css
+++ b/style.css
@@ -262,6 +262,10 @@ header img{
     .mainmessage__text{
         padding:3%;
     }
+    .business__content::after{
+        content: '';
+        width: 26%;
+    }
     .business__content--box{
         flex-basis: 26%;
     }


### PR DESCRIPTION
#1 についての問題を修正。
flex boxの特徴としてspace-betweenは間を均等に開ける処理なので両端によってしまう。
そこで、after疑似要素を使って見えない要素を作って埋めてあげるとうまくいくよ！

`style.css` を参考にしてみてね。