### PR TITLE
SPの一部箇所レイアウト

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
 	
 	<div class="mainmessage">
 		<div class="mainmessage__image">
-			<img src="./face.png">
+			<img class="mainmessage__image__img" src="./face.png">
 			<p class="mainmessage__image__text">代表 | 田代OO</p>
 		</div>
 		<div class="mainmessage__text">

--- a/style.css
+++ b/style.css
@@ -57,6 +57,12 @@ header img{
     flex-wrap: wrap;
     align-items: flex-start;
 }
+.mainmessage__image{
+    width: 100%;
+}
+.mainmessage__image__img{
+    width: 100%;
+}
 .mainmessage__image__text{
     text-align: center;
 }
@@ -254,6 +260,12 @@ header img{
     .mainvisual__text{
         margin:100px 0 120px 0;
         font-size:1.6rem;
+    }
+    .mainmessage__image{
+        width: auto;
+    }
+    .mainmessage__image__img{
+        width: auto;
     }
     .mainmessage__text{
         width:40%;


### PR DESCRIPTION
#2 について修正
> SPで見たときにmainmessage__imageとmainmessage__textの横幅をそろえたい。

横幅は、mainmessage__image要素の中の画像タグに設定されている画像の大きさに依存してしまうので、widthを100%に指定すると良い。

ただ、PCので見たとき横幅がいっぱいになってしまうので、メディアクエリの中で横幅をautoに戻してみた。

なんか、PCのメディアクエリの中で指定するより、新しくSP専用のメディアクエリを作ってその中で記述したほうがキレイなような気もする。